### PR TITLE
feat(coding): add workspace coding sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Maestro is an AI code review and repository analysis assistant built on top of `
 │                               USER INTERFACE                                │
 │                                                                              │
 │  CLI / TUI                                                                  │
-│  • PR review                                                                │
-│  • /ask repository questions                                                │
+│  • workspace coding sessions (ls/read/write/edit; bash opt-in)               │
+│  • PR review and /ask repository questions                                  │
 │  • optional review artifact + skill-store loading                           │
 └──────────────────────────────────────┬───────────────────────────────────────┘
                                        │
@@ -19,8 +19,8 @@ Maestro is an AI code review and repository analysis assistant built on top of `
 │                              MAESTRO SERVICE                                │
 │                                                                              │
 │  Root CLI + TUI routing                                                     │
-│  • review path                                                              │
-│  • ask / overview path                                                      │
+│  • coding-agent path with typed lifecycle events                            │
+│  • review and ask / overview paths                                          │
 │  • model and provider wiring                                                │
 │  • ACE + persisted skill integration                                        │
 └───────────────┬───────────────────────────────────────┬──────────────────────┘
@@ -69,6 +69,7 @@ Maestro is an AI code review and repository analysis assistant built on top of `
 - **Guideline Integration**: review runs can use cached guidelines and repository-aware context.
 - **Artifact-Aware Runtime**: live review runs can load tuned review artifacts and persisted skill stores.
 - **Repository Ask Support**: Maestro can answer codebase questions in addition to reviewing PRs.
+- **Coding Sessions**: Natural-language TUI input runs a workspace-scoped native agent with `ls`, `read`, `write`, and `edit`; unrestricted `bash` requires explicit `--allow-coding-bash`. `/ask` remains read-only QA.
 
 ### **Intelligent Review Pipeline**
 - **Specialized PR Review Agent**: Maestro uses a dedicated Go review path rather than a generic chat wrapper.
@@ -83,7 +84,9 @@ Maestro is an AI code review and repository analysis assistant built on top of `
 
 ### **Terminal UI (TUI v2)**
 - **Interactive Mode**: the root command still launches the modern interactive interface when no PR is provided.
-- **Slash-Command Workflow**: Maestro supports review and ask-style interaction patterns.
+- **Coding-Agent Workflow**: Natural-language prompts can inspect and edit the cloned workspace while typed run/turn/tool events update progress; shell verification is explicit opt-in.
+- **Slash-Command Workflow**: `/ask`, `/review`, session, and subagent commands remain explicit specialist paths.
+- **Cancellation**: Escape cancels the active coding run.
 - **Shared Runtime Wiring**: the same service layer backs both direct CLI review and interactive usage.
 
 ### **Semantic Code Search (Sgrep)**
@@ -219,6 +222,14 @@ The repo still contains ACE and RLM-related runtime wiring, but the most importa
 ### **Model Selection**
 
 ```bash
+# Interactive coding session (natural prompts edit the cloned workspace; /ask is read-only QA)
+go run . --interactive --model google:gemini-2.5-flash --owner XiaoConstantine --repo dspy-go
+
+# Non-interactive coding-session probe
+go run ./cmd/maestro-probe --strategy coding --allow-coding-bash --repo-path /path/to/repo \
+  --question "Inspect the failing test, fix it, and run the focused test" \
+  --model google:gemini-2.5-flash
+
 # Gemini
 go run . --model google:gemini-2.5-flash --owner XiaoConstantine --repo dspy-go --pr 291
 

--- a/cmd/maestro-probe/main.go
+++ b/cmd/maestro-probe/main.go
@@ -90,12 +90,13 @@ func run() error {
 		rlmTargetedArtifactsPath string
 		timeout                  time.Duration
 		verbose                  bool
+		allowCodingBash          bool
 	)
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: maestro-probe --question <question> [flags]\n\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "Runs MaestroService.ProcessRequest(RequestAsk) against a local repository and prints the response metadata as JSON.\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "Scope: ask-side verification only; this does not exercise the PR review/RLM review path.\n\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Runs a Maestro ask or coding request against a local repository and prints response metadata as JSON.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Use --strategy coding for workspace tools; PR review is not exercised.\n\n")
 		flag.PrintDefaults()
 	}
 
@@ -109,12 +110,13 @@ func run() error {
 	flag.StringVar(&modelConfig, "model-config", "", "Additional model configuration")
 	flag.StringVar(&apiKey, "api-key", "", "API key for external model providers")
 	flag.StringVar(&baseURL, "base-url", "", "Optional base URL override")
-	flag.StringVar(&strategy, "strategy", "", "Optional ask strategy override: native, rlm, or rlm-targeted")
+	flag.StringVar(&strategy, "strategy", "", "Execution strategy: native, rlm, rlm-targeted, or coding")
 	flag.StringVar(&memoryPath, "memory-path", "", "Optional Maestro memory path; defaults under /tmp")
 	flag.StringVar(&rlmOverviewArtifactsPath, "rlm-overview-artifact", "", "Optional RLM overview optimized program path")
 	flag.StringVar(&rlmTargetedArtifactsPath, "rlm-targeted-ask-artifact", "", "Optional RLM targeted ask optimized program path")
 	flag.DurationVar(&timeout, "timeout", 5*time.Minute, "Request timeout")
 	flag.BoolVar(&verbose, "verbose", false, "Enable debug logging to stderr")
+	flag.BoolVar(&allowCodingBash, "allow-coding-bash", false, "Allow unrestricted shell commands for --strategy coding")
 	flag.Parse()
 
 	if strings.TrimSpace(question) == "" {
@@ -179,7 +181,8 @@ func run() error {
 	core.GlobalConfig.DefaultLLM = defaultLLM
 
 	previousStrategy, hadStrategy := os.LookupEnv("MAESTRO_FORCE_ASK_STRATEGY")
-	if strategy = strings.TrimSpace(strategy); strategy != "" {
+	strategy = strings.TrimSpace(strategy)
+	if strategy != "" && strategy != "coding" {
 		if err := os.Setenv("MAESTRO_FORCE_ASK_STRATEGY", strategy); err != nil {
 			return fmt.Errorf("set ask strategy: %w", err)
 		}
@@ -195,6 +198,7 @@ func run() error {
 		Owner:                       owner,
 		Repo:                        repo,
 		BudgetManager:               budgetManager,
+		AllowCodingBash:             allowCodingBash,
 	}, nil)
 	if err != nil {
 		return fmt.Errorf("create service: %w", err)
@@ -206,12 +210,13 @@ func run() error {
 	}()
 	service.SetReviewAgent(&localReviewAgent{repoPath: resolvedRepoPath, status: types.NewIndexingStatus()})
 
-	response, err := service.ProcessRequest(ctx, orchestration.Request{
-		Type:     orchestration.RequestAsk,
-		Question: question,
-	})
+	request := orchestration.Request{Type: orchestration.RequestAsk, Question: question}
+	if strategy == "coding" {
+		request = orchestration.Request{Type: orchestration.RequestCoding, Prompt: question}
+	}
+	response, err := service.ProcessRequest(ctx, request)
 	if err != nil {
-		return fmt.Errorf("process ask request: %w", err)
+		return fmt.Errorf("process %s request: %w", request.Type, err)
 	}
 
 	output := probeOutput{

--- a/docs/coding_session.md
+++ b/docs/coding_session.md
@@ -1,0 +1,68 @@
+# Maestro Coding Session
+
+Maestro's interactive default is a workspace coding agent. Natural-language TUI input runs a provider-neutral `dspy-go` native agent against the cloned repository; `/ask` remains the read-only repository-QA route.
+
+## Architecture
+
+```text
+terminal.MaestroModel
+  -> terminal.MaestroBackend
+  -> orchestration.MaestroService
+  -> internal/coding.Session
+  -> native.Agent.ExecuteWithTrace
+```
+
+The boundaries mirror Tau/Pi:
+
+- `dspy-go/pkg/agents` owns the reusable execution loop, typed events, messages, and canonical traces.
+- `internal/coding.Session` owns Maestro's workspace tools, active-run cancellation, and session persistence configuration.
+- `internal/orchestration` selects the cloned workspace and records trace usage.
+- `terminal` maps typed lifecycle events into Bubble Tea display progress.
+
+The frontend does not inspect provider responses or parse result maps.
+
+## Behavior
+
+A coding session registers these workspace-contained file tools by default:
+
+- `ls`
+- `read`
+- `write`
+- `edit`
+
+File tools reject paths outside the cloned repository workspace. Shell execution is disabled by default because setting a working directory is not a sandbox: shell commands can otherwise access absolute paths, `$HOME`, and the network. Pass `--allow-coding-bash` to opt into unrestricted `bash` with the workspace as its initial working directory.
+
+One run may mutate a session at a time. Overlapping prompts are rejected. Press **Esc** to cancel the active coding run. Run, turn, and tool lifecycle events update the TUI progress display. Output and accounting use the operation-scoped `ExecutionTrace` returned by `ExecuteWithTrace`, avoiding races against a mutable last-trace accessor.
+
+The active Maestro session name selects the native session id, so switching or creating a session selects separate persisted coding history.
+
+## Running
+
+```bash
+go run . --interactive \
+  --owner XiaoConstantine \
+  --repo dspy-go \
+  --model google:gemini-2.5-flash
+```
+
+Add `--allow-coding-bash` only when you trust the active model and accept unrestricted shell access.
+
+Enter a task such as:
+
+```text
+Inspect the failing tests, implement the smallest fix, and run the focused tests.
+```
+
+For a non-interactive smoke test:
+
+```bash
+go run ./cmd/maestro-probe \
+  --strategy coding \
+  --repo-path /path/to/repository \
+  --question "Create hello.txt and verify its contents" \
+  --model google:gemini-2.5-flash
+```
+
+## Current boundary
+
+This slice establishes the coding-session execution spine. Tau-level steering/follow-up queues, compaction, session-tree transcript rendering, project instruction discovery, skill/prompt pickers, model switching, and token-delta streaming remain follow-up frontend/session features. They should be added above `dspy-go`'s canonical contracts rather than by creating another execution loop.

--- a/internal/coding/session.go
+++ b/internal/coding/session.go
@@ -1,0 +1,177 @@
+package coding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
+	"github.com/XiaoConstantine/dspy-go/pkg/agents/native"
+	"github.com/XiaoConstantine/dspy-go/pkg/agents/sessionevent"
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/tools/defaults"
+)
+
+var (
+	ErrRunActive     = errors.New("coding session already has an active run")
+	ErrSessionClosed = errors.New("coding session is closed")
+)
+
+type Config struct {
+	LLM          core.LLM
+	Workspace    string
+	SessionID    string
+	SessionStore sessionevent.SessionEventStore
+	SystemPrompt string
+	MaxTurns     int
+	AllowBash    bool
+}
+
+type Session struct {
+	workspace string
+	agent     *native.Agent
+	forwarder *eventForwarder
+
+	runMu   sync.Mutex
+	mu      sync.Mutex
+	stop    context.CancelFunc
+	runDone chan struct{}
+	closed  bool
+}
+
+func NewSession(cfg Config) (*Session, error) {
+	if cfg.LLM == nil {
+		return nil, fmt.Errorf("llm is required")
+	}
+	if strings.TrimSpace(cfg.Workspace) == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+
+	toolset, err := defaults.NewToolset(defaults.Config{Root: cfg.Workspace})
+	if err != nil {
+		return nil, fmt.Errorf("create coding tools: %w", err)
+	}
+	forwarder := &eventForwarder{}
+	agent, err := native.NewAgent(cfg.LLM, native.Config{
+		MaxTurns:          cfg.MaxTurns,
+		SystemPrompt:      cfg.SystemPrompt,
+		SessionID:         strings.TrimSpace(cfg.SessionID),
+		SessionEventStore: cfg.SessionStore,
+		EventSink:         forwarder,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create coding agent: %w", err)
+	}
+	for _, tool := range toolset.Tools() {
+		if tool.Name() == "bash" && !cfg.AllowBash {
+			continue
+		}
+		if err := agent.RegisterTool(tool); err != nil {
+			return nil, fmt.Errorf("register coding tool %s: %w", tool.Name(), err)
+		}
+	}
+
+	return &Session{workspace: toolset.Root(), agent: agent, forwarder: forwarder}, nil
+}
+
+func (s *Session) Workspace() string {
+	if s == nil {
+		return ""
+	}
+	return s.workspace
+}
+
+func (s *Session) Prompt(ctx context.Context, prompt string, sink agents.EventSink) (agents.AgentExecutionResult, error) {
+	if s == nil || s.agent == nil {
+		return agents.AgentExecutionResult{}, fmt.Errorf("coding session is not initialized")
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return agents.AgentExecutionResult{}, fmt.Errorf("prompt is required")
+	}
+	if !s.runMu.TryLock() {
+		return agents.AgentExecutionResult{}, ErrRunActive
+	}
+	defer s.runMu.Unlock()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		cancel()
+		return agents.AgentExecutionResult{}, ErrSessionClosed
+	}
+	done := make(chan struct{})
+	s.stop = cancel
+	s.runDone = done
+	s.mu.Unlock()
+	s.forwarder.Set(sink)
+	defer func() {
+		s.forwarder.Set(nil)
+		cancel()
+		s.mu.Lock()
+		s.stop = nil
+		s.runDone = nil
+		close(done)
+		s.mu.Unlock()
+	}()
+
+	return s.agent.ExecuteWithTrace(runCtx, map[string]any{"task": prompt})
+}
+
+func (s *Session) Close(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	s.closed = true
+	cancel := s.stop
+	done := s.runDone
+	if cancel != nil {
+		cancel()
+	}
+	s.mu.Unlock()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Session) Cancel() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stop == nil {
+		return false
+	}
+	s.stop()
+	return true
+}
+
+type eventForwarder struct {
+	mu   sync.RWMutex
+	sink agents.EventSink
+}
+
+func (f *eventForwarder) Set(sink agents.EventSink) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sink = sink
+}
+
+func (f *eventForwarder) EmitEvent(ctx context.Context, event agents.ExecutionEvent) {
+	f.mu.RLock()
+	sink := f.sink
+	f.mu.RUnlock()
+	if sink != nil {
+		sink.EmitEvent(ctx, event)
+	}
+}

--- a/internal/coding/session_test.go
+++ b/internal/coding/session_test.go
@@ -1,0 +1,191 @@
+package coding
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+)
+
+func TestSessionPromptRunsWorkspaceToolsAndEmitsLifecycle(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "README.md"), []byte("# fixture\n"), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	llm := &scriptedLLM{results: []map[string]any{
+		{"function_call": map[string]any{"name": "read", "arguments": map[string]any{"path": "README.md"}}},
+		{"function_call": map[string]any{"name": "Finish", "arguments": map[string]any{"answer": "README inspected"}}},
+	}}
+	session, err := NewSession(Config{LLM: llm, Workspace: workspace, SessionID: "coding-test"})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	var events []agents.ExecutionEvent
+	result, err := session.Prompt(context.Background(), "Inspect README.md", agents.EventSinkFunc(func(_ context.Context, event agents.ExecutionEvent) {
+		events = append(events, event)
+	}))
+	if err != nil {
+		t.Fatalf("Prompt() error = %v", err)
+	}
+	if got := result.Output["final_answer"]; got != "README inspected" {
+		t.Fatalf("final answer = %#v, want README inspected", got)
+	}
+	if result.Trace == nil || result.Trace.Status != agents.TraceStatusSuccess {
+		t.Fatalf("trace = %#v, want successful trace", result.Trace)
+	}
+	if len(result.Trace.Steps) == 0 || result.Trace.Steps[0].Tool != "read" {
+		t.Fatalf("trace steps = %#v, want read tool", result.Trace.Steps)
+	}
+	if len(events) == 0 {
+		t.Fatal("events = nil, want typed lifecycle events")
+	}
+	if _, ok := events[0].Payload.(agents.RunStartedEvent); !ok {
+		t.Fatalf("first event = %T, want RunStartedEvent", events[0].Payload)
+	}
+	if _, ok := events[len(events)-1].Payload.(agents.RunFinishedEvent); !ok {
+		t.Fatalf("last event = %T, want RunFinishedEvent", events[len(events)-1].Payload)
+	}
+}
+
+func TestSessionCloseIsTerminal(t *testing.T) {
+	session, err := NewSession(Config{LLM: &scriptedLLM{}, Workspace: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	if err := session.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if _, err := session.Prompt(context.Background(), "after close", nil); err != ErrSessionClosed {
+		t.Fatalf("Prompt() error = %v, want %v", err, ErrSessionClosed)
+	}
+}
+
+func TestSessionRequiresExplicitBashOptIn(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowBash bool
+		wantError bool
+	}{
+		{name: "disabled by default", wantError: true},
+		{name: "explicitly enabled", allowBash: true, wantError: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llm := &scriptedLLM{results: []map[string]any{
+				{"function_call": map[string]any{"name": "bash", "arguments": map[string]any{"command": "printf ok"}}},
+				{"function_call": map[string]any{"name": "Finish", "arguments": map[string]any{"answer": "done"}}},
+			}}
+			session, err := NewSession(Config{LLM: llm, Workspace: t.TempDir(), AllowBash: tt.allowBash})
+			if err != nil {
+				t.Fatalf("NewSession() error = %v", err)
+			}
+			result, err := session.Prompt(context.Background(), "run shell", nil)
+			if err != nil {
+				t.Fatalf("Prompt() error = %v", err)
+			}
+			if result.Trace == nil || len(result.Trace.Steps) == 0 {
+				t.Fatalf("trace = %#v, want bash step", result.Trace)
+			}
+			gotError := result.Trace.Steps[0].Error != ""
+			if gotError != tt.wantError {
+				t.Fatalf("bash step error = %q, wantError=%v", result.Trace.Steps[0].Error, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestSessionRejectsOverlappingRunsAndCancels(t *testing.T) {
+	llm := &scriptedLLM{block: true, started: make(chan struct{})}
+	session, err := NewSession(Config{LLM: llm, Workspace: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := session.Prompt(context.Background(), "wait", nil)
+		done <- err
+	}()
+	select {
+	case <-llm.started:
+	case <-time.After(time.Second):
+		t.Fatal("model did not start")
+	}
+
+	if _, err := session.Prompt(context.Background(), "overlap", nil); err != ErrRunActive {
+		t.Fatalf("overlapping Prompt() error = %v, want %v", err, ErrRunActive)
+	}
+	if !session.Cancel() {
+		t.Fatal("Cancel() = false, want true")
+	}
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("canceled Prompt() error = nil")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled prompt did not return")
+	}
+}
+
+type scriptedLLM struct {
+	mu        sync.Mutex
+	results   []map[string]any
+	index     int
+	block     bool
+	started   chan struct{}
+	startOnce sync.Once
+}
+
+func (m *scriptedLLM) Generate(context.Context, string, ...core.GenerateOption) (*core.LLMResponse, error) {
+	return nil, fmt.Errorf("unexpected Generate call")
+}
+func (m *scriptedLLM) GenerateWithJSON(context.Context, string, ...core.GenerateOption) (map[string]any, error) {
+	return nil, fmt.Errorf("unexpected GenerateWithJSON call")
+}
+func (m *scriptedLLM) GenerateWithFunctions(ctx context.Context, _ string, _ []map[string]any, _ ...core.GenerateOption) (map[string]any, error) {
+	if m.block {
+		m.startOnce.Do(func() {
+			if m.started != nil {
+				close(m.started)
+			}
+		})
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.index >= len(m.results) {
+		return nil, fmt.Errorf("no scripted result")
+	}
+	result := m.results[m.index]
+	m.index++
+	return result, nil
+}
+func (m *scriptedLLM) CreateEmbedding(context.Context, string, ...core.EmbeddingOption) (*core.EmbeddingResult, error) {
+	return nil, fmt.Errorf("unexpected CreateEmbedding call")
+}
+func (m *scriptedLLM) CreateEmbeddings(context.Context, []string, ...core.EmbeddingOption) (*core.BatchEmbeddingResult, error) {
+	return nil, fmt.Errorf("unexpected CreateEmbeddings call")
+}
+func (m *scriptedLLM) StreamGenerate(context.Context, string, ...core.GenerateOption) (*core.StreamResponse, error) {
+	return nil, fmt.Errorf("unexpected StreamGenerate call")
+}
+func (m *scriptedLLM) GenerateWithContent(context.Context, []core.ContentBlock, ...core.GenerateOption) (*core.LLMResponse, error) {
+	return nil, fmt.Errorf("unexpected GenerateWithContent call")
+}
+func (m *scriptedLLM) StreamGenerateWithContent(context.Context, []core.ContentBlock, ...core.GenerateOption) (*core.StreamResponse, error) {
+	return nil, fmt.Errorf("unexpected StreamGenerateWithContent call")
+}
+func (m *scriptedLLM) ProviderName() string { return "scripted" }
+func (m *scriptedLLM) ModelID() string      { return "scripted-model" }
+func (m *scriptedLLM) Capabilities() []core.Capability {
+	return []core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling}
+}

--- a/internal/orchestration/coding_session_test.go
+++ b/internal/orchestration/coding_session_test.go
@@ -1,0 +1,214 @@
+package orchestration
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
+	"github.com/XiaoConstantine/dspy-go/pkg/logging"
+	maestrocoding "github.com/XiaoConstantine/maestro/internal/coding"
+)
+
+func TestCodingSessionIDUsesReservedCollisionResistantNamespace(t *testing.T) {
+	first := codingSessionID("alpha")
+	second := codingSessionID("alpha-coding")
+	if !strings.HasPrefix(first, codingSessionNamespace) {
+		t.Fatalf("codingSessionID(alpha) = %q, want reserved prefix", first)
+	}
+	if first == "alpha" || first == "alpha-coding" {
+		t.Fatalf("codingSessionID(alpha) = %q, collides with user-derived name", first)
+	}
+	if first == second {
+		t.Fatalf("coding session IDs collide: %q", first)
+	}
+}
+
+func TestCodingSessionReplacementInvalidatesClosedCacheOnConstructionFailure(t *testing.T) {
+	llm := &capturingBenchmarkLLM{capabilities: []core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling}}
+	workspace := t.TempDir()
+	oldSession, err := maestrocoding.NewSession(maestrocoding.Config{LLM: llm, Workspace: workspace})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	service := &MaestroService{
+		config:          &ServiceConfig{},
+		currentSession:  "alpha",
+		codingSession:   oldSession,
+		codingWorkspace: workspace,
+		codingSessionID: codingSessionID("alpha"),
+	}
+
+	previousLLM := core.GlobalConfig.DefaultLLM
+	t.Cleanup(func() { core.GlobalConfig.DefaultLLM = previousLLM })
+	core.GlobalConfig.DefaultLLM = nil
+	if _, err := service.codingSessionFor(context.Background(), t.TempDir()); err == nil {
+		t.Fatal("codingSessionFor() error = nil with no default LLM")
+	}
+	core.GlobalConfig.DefaultLLM = llm
+
+	replacement, err := service.codingSessionFor(context.Background(), workspace)
+	if err != nil {
+		t.Fatalf("codingSessionFor() retry error = %v", err)
+	}
+	if replacement == oldSession {
+		t.Fatal("codingSessionFor() reused terminally closed session")
+	}
+}
+
+func TestCodingSessionAdmissionRejectsWorkAfterShutdownStarts(t *testing.T) {
+	service := &MaestroService{
+		config:         &ServiceConfig{},
+		currentSession: "alpha",
+		pool:           &AgentPool{},
+		logger:         logging.GetLogger(),
+	}
+	if err := service.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if _, err := service.codingSessionFor(context.Background(), t.TempDir()); err == nil || !strings.Contains(err.Error(), "shutting down") {
+		t.Fatalf("codingSessionFor() error = %v, want shutdown rejection", err)
+	}
+}
+
+func TestShutdownStopsCodingBeforeClosingWorkspaceOwner(t *testing.T) {
+	llm := newBlockingCodingLLM(false)
+	session, err := maestrocoding.NewSession(maestrocoding.Config{LLM: llm, Workspace: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	var closedBeforeStop atomic.Bool
+	reviewAgent := &shutdownOrderReviewAgent{
+		budgetAwareReviewAgent: &budgetAwareReviewAgent{},
+		onClose: func() {
+			if !llm.exited.Load() {
+				closedBeforeStop.Store(true)
+			}
+		},
+	}
+	service := &MaestroService{
+		pool:          &AgentPool{reviewAgent: reviewAgent},
+		codingSession: session,
+		logger:        logging.GetLogger(),
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := session.Prompt(context.Background(), "block", nil)
+		done <- err
+	}()
+	<-llm.started
+
+	if err := service.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if closedBeforeStop.Load() {
+		t.Fatal("review workspace owner closed before coding model exited")
+	}
+	<-done
+}
+
+func TestShutdownTimeoutSkipsWorkspaceOwnerClose(t *testing.T) {
+	llm := newBlockingCodingLLM(true)
+	session, err := maestrocoding.NewSession(maestrocoding.Config{LLM: llm, Workspace: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	var reviewClosed atomic.Bool
+	service := &MaestroService{
+		pool: &AgentPool{reviewAgent: &shutdownOrderReviewAgent{
+			budgetAwareReviewAgent: &budgetAwareReviewAgent{},
+			onClose:                func() { reviewClosed.Store(true) },
+		}},
+		codingSession: session,
+		logger:        logging.GetLogger(),
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := session.Prompt(context.Background(), "resist cancellation", nil)
+		done <- err
+	}()
+	<-llm.started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := service.Shutdown(ctx); err == nil {
+		t.Fatal("Shutdown() error = nil, want timeout")
+	}
+	if reviewClosed.Load() {
+		t.Fatal("review workspace owner closed after coding close timed out")
+	}
+	close(llm.release)
+	<-done
+}
+
+type blockingCodingLLM struct {
+	*capturingBenchmarkLLM
+	started      chan struct{}
+	release      chan struct{}
+	ignoreCancel bool
+	exited       atomic.Bool
+}
+
+func newBlockingCodingLLM(ignoreCancel bool) *blockingCodingLLM {
+	return &blockingCodingLLM{
+		capturingBenchmarkLLM: &capturingBenchmarkLLM{capabilities: []core.Capability{core.CapabilityCompletion, core.CapabilityToolCalling}},
+		started:               make(chan struct{}),
+		release:               make(chan struct{}),
+		ignoreCancel:          ignoreCancel,
+	}
+}
+
+func (l *blockingCodingLLM) GenerateWithFunctions(ctx context.Context, _ string, _ []map[string]interface{}, _ ...core.GenerateOption) (map[string]interface{}, error) {
+	close(l.started)
+	if l.ignoreCancel {
+		<-l.release
+	} else {
+		<-ctx.Done()
+	}
+	l.exited.Store(true)
+	return nil, ctx.Err()
+}
+
+type shutdownOrderReviewAgent struct {
+	*budgetAwareReviewAgent
+	onClose func()
+}
+
+func (a *shutdownOrderReviewAgent) Close() error {
+	if a.onClose != nil {
+		a.onClose()
+	}
+	return nil
+}
+
+func TestCodingAnswerSurfacesStoppedRunDiagnostic(t *testing.T) {
+	answer, err := codingAnswer(agents.AgentExecutionResult{
+		Output: map[string]any{"completed": false, "error": "max turns reached without completion"},
+		Trace: &agents.ExecutionTrace{
+			Status:           agents.TraceStatusPartial,
+			TerminationCause: "max_turns",
+		},
+	})
+	if err != nil {
+		t.Fatalf("codingAnswer() error = %v", err)
+	}
+	if !strings.Contains(answer, "max turns reached") {
+		t.Fatalf("codingAnswer() = %q, want max-turn diagnostic", answer)
+	}
+}
+
+func TestCodingAnswerSurfacesPartialTraceWithoutOutputError(t *testing.T) {
+	answer, err := codingAnswer(agents.AgentExecutionResult{Trace: &agents.ExecutionTrace{
+		Status:           agents.TraceStatusPartial,
+		TerminationCause: "stopped",
+	}})
+	if err != nil {
+		t.Fatalf("codingAnswer() error = %v", err)
+	}
+	if answer != "Coding run stopped: stopped" {
+		t.Fatalf("codingAnswer() = %q, want visible stop diagnostic", answer)
+	}
+}

--- a/internal/orchestration/service.go
+++ b/internal/orchestration/service.go
@@ -3,11 +3,14 @@ package orchestration
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +21,7 @@ import (
 	"github.com/XiaoConstantine/dspy-go/pkg/logging"
 	maestroace "github.com/XiaoConstantine/maestro/internal/ace"
 	maestrobudget "github.com/XiaoConstantine/maestro/internal/budget"
+	maestrocoding "github.com/XiaoConstantine/maestro/internal/coding"
 	"github.com/XiaoConstantine/maestro/internal/subagent"
 	"github.com/XiaoConstantine/maestro/internal/types"
 	"github.com/briandowns/spinner"
@@ -58,6 +62,7 @@ type RequestType string
 
 const (
 	RequestReview RequestType = "review"
+	RequestCoding RequestType = "coding"
 	RequestAsk    RequestType = "ask"
 	RequestClaude RequestType = "claude"
 	RequestGemini RequestType = "gemini"
@@ -80,6 +85,7 @@ type ServiceConfig struct {
 	ReviewWorkers               int
 	BudgetConfig                maestrobudget.Config
 	BudgetManager               *maestrobudget.BudgetManager
+	AllowCodingBash             bool
 }
 
 type Request struct {
@@ -90,6 +96,7 @@ type Request struct {
 	TaskType   string // e.g., "search", "generate", "review"
 	Context    map[string]interface{}
 	OnProgress func(status string)
+	EventSink  agents.EventSink
 }
 
 type Response struct {
@@ -114,6 +121,12 @@ type MaestroService struct {
 	rlmOverviewSkillStore  skills.Store
 	rlmOverviewSkillDomain string
 	budgetManager          *maestrobudget.BudgetManager
+
+	codingMu           sync.Mutex
+	codingSession      *maestrocoding.Session
+	codingSessionID    string
+	codingWorkspace    string
+	codingShuttingDown bool
 
 	mu          sync.RWMutex
 	initialized bool
@@ -273,6 +286,8 @@ func (s *MaestroService) ProcessRequest(ctx context.Context, request Request) (*
 	switch request.Type {
 	case RequestReview:
 		return s.withBudgetMetadata(s.handleReview(ctx, request))
+	case RequestCoding:
+		return s.withBudgetMetadata(s.handleCoding(ctx, request))
 	case RequestAsk:
 		return s.withBudgetMetadata(s.handleAsk(ctx, request))
 	case RequestClaude:
@@ -324,11 +339,126 @@ func (s *MaestroService) handleReview(ctx context.Context, request Request) (*Re
 	}, nil
 }
 
-func (s *MaestroService) handleAsk(ctx context.Context, request Request) (*Response, error) {
-	repoPath := ""
-	if reviewAgent, err := s.pool.GetReviewAgent(ctx); err == nil {
-		repoPath = reviewAgent.ClonedRepoPath()
+func (s *MaestroService) handleCoding(ctx context.Context, request Request) (*Response, error) {
+	workspace := s.repositoryWorkspace(ctx)
+	if workspace == "" {
+		return &Response{
+			Type:   RequestCoding,
+			Answer: "Repository is still being cloned. Please wait a moment and try again.",
+		}, nil
 	}
+
+	session, err := s.codingSessionFor(ctx, workspace)
+	if err != nil {
+		return nil, err
+	}
+	result, err := session.Prompt(ctx, request.Prompt, request.EventSink)
+	s.recordExecutionTraceUsage(ctx, "coding.native", result.Trace)
+	if err != nil {
+		return nil, err
+	}
+
+	answer, err := codingAnswer(result)
+	if err != nil {
+		return nil, err
+	}
+	return &Response{
+		Type:   RequestCoding,
+		Answer: answer,
+		Metadata: map[string]interface{}{
+			"workspace": workspace,
+			"trace":     result.Trace,
+		},
+	}, nil
+}
+
+func codingAnswer(result agents.AgentExecutionResult) (string, error) {
+	answer := strings.TrimSpace(stringValue(result.Output["final_answer"]))
+	if answer == "" && result.Trace != nil {
+		answer = strings.TrimSpace(stringValue(result.Trace.Output["final_answer"]))
+	}
+	if answer == "" {
+		if diagnostic := strings.TrimSpace(stringValue(result.Output["error"])); diagnostic != "" {
+			if result.Trace != nil && result.Trace.Status == agents.TraceStatusPartial {
+				return "Coding run stopped: " + diagnostic, nil
+			}
+			return "", fmt.Errorf("coding run failed: %s", diagnostic)
+		}
+		if result.Trace != nil && result.Trace.Status != agents.TraceStatusSuccess {
+			diagnostic := strings.TrimSpace(result.Trace.Error)
+			if diagnostic == "" {
+				diagnostic = strings.TrimSpace(result.Trace.TerminationCause)
+			}
+			if diagnostic == "" {
+				diagnostic = "no final answer"
+			}
+			return "Coding run stopped: " + diagnostic, nil
+		}
+	}
+	if answer == "" {
+		return "", fmt.Errorf("coding run completed without a final answer")
+	}
+	return answer, nil
+}
+
+func (s *MaestroService) codingSessionFor(ctx context.Context, workspace string) (*maestrocoding.Session, error) {
+	s.codingMu.Lock()
+	defer s.codingMu.Unlock()
+	if s.codingShuttingDown {
+		return nil, fmt.Errorf("coding service is shutting down")
+	}
+
+	sessionID := codingSessionID(s.GetCurrentSession())
+	if s.codingSession != nil && s.codingWorkspace == workspace && s.codingSessionID == sessionID {
+		return s.codingSession, nil
+	}
+	if s.codingSession != nil {
+		if err := s.codingSession.Close(ctx); err != nil {
+			return nil, fmt.Errorf("close previous coding session: %w", err)
+		}
+		s.codingSession = nil
+		s.codingWorkspace = ""
+		s.codingSessionID = ""
+	}
+	session, err := maestrocoding.NewSession(maestrocoding.Config{
+		LLM:          core.GetDefaultLLM(),
+		Workspace:    workspace,
+		SessionID:    sessionID,
+		SessionStore: s.sessionStore,
+		AllowBash:    s.config.AllowCodingBash,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create coding session: %w", err)
+	}
+	s.codingSession = session
+	s.codingWorkspace = workspace
+	s.codingSessionID = sessionID
+	return session, nil
+}
+
+const codingSessionNamespace = "maestro:internal:coding:"
+
+func codingSessionID(sessionName string) string {
+	digest := sha256.Sum256([]byte(sessionName))
+	return codingSessionNamespace + hex.EncodeToString(digest[:])
+}
+
+func (s *MaestroService) repositoryWorkspace(ctx context.Context) string {
+	if reviewAgent, err := s.pool.GetReviewAgent(ctx); err == nil {
+		return reviewAgent.ClonedRepoPath()
+	}
+	return ""
+}
+
+func (s *MaestroService) CancelCodingRun() bool {
+	s.codingMu.Lock()
+	session := s.codingSession
+	s.codingMu.Unlock()
+	return session != nil && session.Cancel()
+}
+
+func (s *MaestroService) handleAsk(ctx context.Context, request Request) (*Response, error) {
+	repoPath := s.repositoryWorkspace(ctx)
 
 	if repoPath == "" {
 		return &Response{
@@ -498,22 +628,41 @@ func (s *MaestroService) IsReady() bool {
 }
 
 func (s *MaestroService) Shutdown(ctx context.Context) error {
-	s.pool.Shutdown(ctx)
+	var shutdownErrs []error
+	codingStopped := true
 
-	if s.sessionStore != nil {
-		if err := s.sessionStore.Close(); err != nil {
-			s.logger.Warn(ctx, "Failed to close session event store: %v", err)
+	s.codingMu.Lock()
+	s.codingShuttingDown = true
+	codingSession := s.codingSession
+	s.codingMu.Unlock()
+	if codingSession != nil {
+		if err := codingSession.Close(ctx); err != nil {
+			codingStopped = false
+			s.logger.Warn(ctx, "Failed to stop coding session: %v", err)
+			shutdownErrs = append(shutdownErrs, fmt.Errorf("stop coding session: %w", err))
 		}
 	}
 
-	// Close ACE manager to flush pending learnings
+	if codingStopped {
+		s.pool.Shutdown(ctx)
+	}
+
+	if codingStopped && s.sessionStore != nil {
+		if err := s.sessionStore.Close(); err != nil {
+			s.logger.Warn(ctx, "Failed to close session event store: %v", err)
+			shutdownErrs = append(shutdownErrs, fmt.Errorf("close session event store: %w", err))
+		}
+	}
+
+	// Close ACE independently so pending learnings are flushed even when a run resists cancellation.
 	if s.aceManager != nil {
 		if err := s.aceManager.Close(); err != nil {
 			s.logger.Warn(ctx, "Failed to close ACE manager: %v", err)
+			shutdownErrs = append(shutdownErrs, fmt.Errorf("close ACE manager: %w", err))
 		}
 	}
 
-	return nil
+	return errors.Join(shutdownErrs...)
 }
 
 // GetACEManager returns the ACE manager for self-improving agent capabilities.
@@ -546,6 +695,9 @@ func (s *MaestroService) CreateSession(ctx context.Context, name string) error {
 	if name == "" {
 		name = generateSessionName()
 	}
+	if strings.HasPrefix(name, "maestro:internal:") {
+		return fmt.Errorf("session name uses reserved Maestro namespace")
+	}
 
 	initialContext := map[string]interface{}{
 		"owner":   s.config.Owner,
@@ -571,6 +723,9 @@ func (s *MaestroService) CreateSession(ctx context.Context, name string) error {
 
 // SwitchSession switches to an existing session.
 func (s *MaestroService) SwitchSession(ctx context.Context, name string) error {
+	if strings.HasPrefix(name, "maestro:internal:") {
+		return fmt.Errorf("session name uses reserved Maestro namespace")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -651,7 +806,17 @@ func (s *MaestroService) ListSessions(ctx context.Context) ([]subagent.Session, 
 		return nil, fmt.Errorf("session manager not initialized")
 	}
 
-	return s.sessionManager.ListSessions()
+	sessions, err := s.sessionManager.ListSessions()
+	if err != nil {
+		return nil, err
+	}
+	visible := sessions[:0]
+	for _, session := range sessions {
+		if !strings.HasPrefix(session.ID, "maestro:internal:") {
+			visible = append(visible, session)
+		}
+	}
+	return visible, nil
 }
 
 // GetCurrentSession returns the name of the current session.

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
 	"github.com/XiaoConstantine/dspy-go/pkg/agents/ace"
 	"github.com/XiaoConstantine/dspy-go/pkg/core"
 	"github.com/XiaoConstantine/dspy-go/pkg/llms"
@@ -109,6 +110,7 @@ type config struct {
 	prNumber               int
 	verbose                bool
 	verifyOnly             bool
+	allowCodingBash        bool
 	modelProvider          string
 	modelName              string
 	modelConfig            string // For additional model-specific configuration
@@ -249,6 +251,7 @@ Available slash commands in interactive mode:
 	rootCmd.PersistentFlags().IntVar(&cfg.prNumber, "pr", 0, "Pull request number")
 	rootCmd.PersistentFlags().BoolVar(&cfg.verbose, "verbose", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().BoolVar(&cfg.verifyOnly, "verify-only", false, "Only verify token permissions")
+	rootCmd.PersistentFlags().BoolVar(&cfg.allowCodingBash, "allow-coding-bash", false, "Allow the coding agent to run unrestricted shell commands in the workspace")
 
 	rootCmd.PersistentFlags().BoolP("interactive", "i", false, "Run in interactive mode")
 
@@ -599,6 +602,47 @@ func (a *TUIServiceAdapter) ReviewPR(ctx context.Context, prNumber int, onProgre
 	return result, nil
 }
 
+func (a *TUIServiceAdapter) RunCodingTask(ctx context.Context, prompt string, onEvent func(terminal.CodingEvent)) (string, error) {
+	var sink agents.EventSink
+	if onEvent != nil {
+		sink = agents.EventSinkFunc(func(_ context.Context, event agents.ExecutionEvent) {
+			if mapped, ok := mapCodingEvent(event); ok {
+				onEvent(mapped)
+			}
+		})
+	}
+	response, err := a.service.ProcessRequest(ctx, orchestration.Request{
+		Type:      orchestration.RequestCoding,
+		Prompt:    prompt,
+		EventSink: sink,
+	})
+	if err != nil {
+		return "", err
+	}
+	return response.Answer, nil
+}
+
+func (a *TUIServiceAdapter) CancelCodingTask() bool {
+	return a.service != nil && a.service.CancelCodingRun()
+}
+
+func mapCodingEvent(event agents.ExecutionEvent) (terminal.CodingEvent, bool) {
+	switch payload := event.Payload.(type) {
+	case agents.RunStartedEvent:
+		return terminal.CodingEvent{Kind: "run", Status: "started", Detail: payload.Task}, true
+	case agents.TurnStartedEvent:
+		return terminal.CodingEvent{Kind: "turn", Status: "started", Detail: fmt.Sprintf("Turn %d/%d", payload.Turn, payload.MaxTurns)}, true
+	case agents.ToolExecutionStartedEvent:
+		return terminal.CodingEvent{Kind: "tool", Tool: payload.Call.Name, Status: "started", Detail: fmt.Sprintf("Running %s", payload.Call.Name)}, true
+	case agents.ToolCallFinishedEvent:
+		return terminal.CodingEvent{Kind: "tool", Tool: payload.Call.Name, Status: string(payload.Status), Detail: fmt.Sprintf("%s %s", payload.Call.Name, payload.Status)}, true
+	case agents.RunFinishedEvent:
+		return terminal.CodingEvent{Kind: "run", Status: string(payload.Status), Detail: payload.Diagnostic}, true
+	default:
+		return terminal.CodingEvent{}, false
+	}
+}
+
 func (a *TUIServiceAdapter) AskQuestion(ctx context.Context, question string) (string, error) {
 	response, err := a.service.ProcessRequest(ctx, orchestration.Request{
 		Type:     orchestration.RequestAsk,
@@ -756,6 +800,7 @@ func runModernUI(cfg *config) error {
 		GitHubToken:               cfg.githubToken,
 		IndexWorkers:              cfg.indexWorkers,
 		ReviewWorkers:             cfg.reviewWorkers,
+		AllowCodingBash:           cfg.allowCodingBash,
 	}, githubTools)
 	if err != nil {
 		return fmt.Errorf("failed to create service: %w", err)

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,28 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+
+	"github.com/XiaoConstantine/dspy-go/pkg/agents"
+	"github.com/XiaoConstantine/dspy-go/pkg/core"
 )
+
+func TestMapCodingEventMapsToolLifecycle(t *testing.T) {
+	event, ok := mapCodingEvent(agents.ExecutionEvent{Payload: agents.ToolExecutionStartedEvent{
+		Call: core.ToolCall{Name: "edit"},
+	}})
+	if !ok {
+		t.Fatal("mapCodingEvent() ok = false")
+	}
+	if event.Kind != "tool" || event.Tool != "edit" || event.Status != "started" {
+		t.Fatalf("event = %#v, want started edit tool", event)
+	}
+}
+
+func TestMapCodingEventIgnoresMessageAdded(t *testing.T) {
+	if _, ok := mapCodingEvent(agents.ExecutionEvent{Payload: agents.MessageAddedEvent{}}); ok {
+		t.Fatal("mapCodingEvent() ok = true, want false")
+	}
+}
 
 func TestResolveCLIStoragePath_DirectoryPathUsesRepoDBName(t *testing.T) {
 	cfg := &config{

--- a/terminal/backend.go
+++ b/terminal/backend.go
@@ -8,7 +8,13 @@ type MaestroBackend interface {
 	// ReviewPR initiates a PR review and returns comments.
 	ReviewPR(ctx context.Context, prNumber int, onProgress func(status string)) ([]ReviewComment, error)
 
-	// AskQuestion sends a question to the agent and returns the response.
+	// RunCodingTask executes a workspace-scoped coding-agent prompt.
+	RunCodingTask(ctx context.Context, prompt string, onEvent func(CodingEvent)) (string, error)
+
+	// CancelCodingTask cancels the active coding-agent run.
+	CancelCodingTask() bool
+
+	// AskQuestion sends a read-only question to the repository QA agent.
 	AskQuestion(ctx context.Context, question string) (string, error)
 
 	// Claude sends a prompt to Claude CLI subagent and returns the response.
@@ -38,6 +44,13 @@ type MaestroBackend interface {
 }
 
 // SessionInfo contains metadata about a session.
+type CodingEvent struct {
+	Kind   string
+	Tool   string
+	Status string
+	Detail string
+}
+
 type SessionInfo struct {
 	Name      string
 	CreatedAt string
@@ -83,6 +96,12 @@ func (b *NoOpBackend) ReviewPR(ctx context.Context, prNumber int, onProgress fun
 	}
 	return nil, nil
 }
+
+func (b *NoOpBackend) RunCodingTask(ctx context.Context, prompt string, onEvent func(CodingEvent)) (string, error) {
+	return "Backend not configured. Please initialize with a valid agent.", nil
+}
+
+func (b *NoOpBackend) CancelCodingTask() bool { return false }
 
 func (b *NoOpBackend) AskQuestion(ctx context.Context, question string) (string, error) {
 	return "Backend not configured. Please initialize with a valid agent.", nil

--- a/terminal/input_model.go
+++ b/terminal/input_model.go
@@ -12,7 +12,7 @@ import (
 type InputCommandHandler func(cmd string, args []string) tea.Cmd
 
 // InputQuestionHandler is called when a natural language question is entered.
-type InputQuestionHandler func(question string) tea.Cmd
+type InputQuestionHandler func(question string) (tea.Cmd, bool)
 
 // InputModel handles text input and command parsing.
 type InputModel struct {
@@ -145,22 +145,26 @@ func (m *InputModel) Update(msg tea.Msg) (*InputModel, tea.Cmd) {
 				return m, nil
 			}
 
-			// Add to history
-			m.addToHistory(value)
+			var questionCmd tea.Cmd
+			if !strings.HasPrefix(value, "/") && m.onQuestion != nil {
+				var accepted bool
+				questionCmd, accepted = m.onQuestion(value)
+				if !accepted {
+					return m, questionCmd
+				}
+			}
 
-			// Clear input and suggestions
+			// Add accepted input to history, then clear the editor.
+			m.addToHistory(value)
 			m.textarea.Reset()
 			m.showSuggestions = false
 			m.suggestions = nil
 			m.selectedSuggestion = 0
 
-			// Parse and handle
 			if strings.HasPrefix(value, "/") {
 				return m, m.parseCommand(value)
 			}
-			if m.onQuestion != nil {
-				return m, m.onQuestion(value)
-			}
+			return m, questionCmd
 
 		case "up":
 			// Navigate suggestions if showing

--- a/terminal/maestro_model.go
+++ b/terminal/maestro_model.go
@@ -59,12 +59,20 @@ type MaestroModel struct {
 
 	// Program reference for sending async updates
 	program *tea.Program
+
+	codingRunActive bool
+	codingCancel    context.CancelFunc
 }
 
 // ProgressMsg is sent to update the UI with progress information.
 type ProgressMsg struct {
 	Status string
 	Detail string
+}
+
+type CodingResultMsg struct {
+	Content string
+	Error   error
 }
 
 // NewMaestroModel creates a new root TUI model.
@@ -105,7 +113,7 @@ func NewMaestroModel(cfg *MaestroConfig, backend MaestroBackend) *MaestroModel {
 	m.registerCommands()
 
 	// Add welcome message
-	m.addMessage("assistant", "Welcome to Maestro! Type /help for commands or ask questions directly.")
+	m.addMessage("assistant", "Welcome to Maestro! Enter a coding task, or use /ask for read-only repository questions.")
 
 	return m
 }
@@ -168,6 +176,16 @@ func (m *MaestroModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "esc":
 			// Handle escape based on current state
+			if m.codingRunActive {
+				if m.codingCancel != nil {
+					m.codingCancel()
+				}
+				if m.backend != nil {
+					m.backend.CancelCodingTask()
+				}
+				m.progressModel.SetMessage("Canceling...")
+				return m, nil
+			}
 			if m.commandPalette.IsVisible() {
 				m.commandPalette.Hide()
 				return m, nil
@@ -301,6 +319,20 @@ func (m *MaestroModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.addMessage("assistant", msg.Content)
 		m.statusBar.SetMessage("")
 		m.progressModel.Hide() // Ensure progress is hidden when response arrives
+
+	case CodingResultMsg:
+		if m.codingCancel != nil {
+			m.codingCancel()
+			m.codingCancel = nil
+		}
+		m.codingRunActive = false
+		m.statusBar.SetMessage("")
+		m.progressModel.Hide()
+		if msg.Error != nil {
+			m.addMessage("system", fmt.Sprintf("Error: %v", msg.Error))
+		} else {
+			m.addMessage("assistant", msg.Content)
+		}
 
 	case SessionPickerMsg:
 		// Enter session picker mode
@@ -712,31 +744,36 @@ func (m *MaestroModel) handleCommand(cmd string, args []string) tea.Cmd {
 	}
 }
 
-// handleQuestion processes a natural language question.
-func (m *MaestroModel) handleQuestion(question string) tea.Cmd {
+// handleQuestion processes natural language as a workspace coding task.
+func (m *MaestroModel) handleQuestion(question string) (tea.Cmd, bool) {
+	if m.codingRunActive {
+		return func() tea.Msg {
+			return ErrorMsg{Error: fmt.Errorf("a coding run is already active; press Esc to cancel it")}
+		}, false
+	}
 	m.addMessage("user", question)
+	m.codingRunActive = true
+	runCtx, cancel := context.WithCancel(m.ctx)
+	m.codingCancel = cancel
 
-	// Start progress display
-	startCmd := m.progressModel.Start("Thinking...")
-
-	// Capture program reference
+	startCmd := m.progressModel.Start("Starting coding agent...")
 	prog := m.program
 
-	askCmd := func() tea.Msg {
+	taskCmd := func() tea.Msg {
 		if m.backend == nil || !m.backend.IsReady() {
-			prog.Send(ProgressMsg{Status: ""}) // Clear progress
-			return ResponseMsg{Content: "Backend not ready. Please configure the agent."}
+			return CodingResultMsg{Error: fmt.Errorf("backend not ready; configure the agent")}
 		}
-
-		response, err := m.backend.AskQuestion(m.ctx, question)
-		prog.Send(ProgressMsg{Status: ""}) // Clear progress
-		if err != nil {
-			return ErrorMsg{Error: err}
-		}
-		return ResponseMsg{Content: response}
+		response, err := m.backend.RunCodingTask(runCtx, question, func(event CodingEvent) {
+			status := event.Detail
+			if status == "" {
+				status = event.Status
+			}
+			prog.Send(ProgressMsg{Status: status, Detail: event.Tool})
+		})
+		return CodingResultMsg{Content: response, Error: err}
 	}
 
-	return tea.Batch(startCmd, askCmd)
+	return tea.Batch(startCmd, taskCmd), true
 }
 
 // Command implementations
@@ -760,6 +797,7 @@ func (m *MaestroModel) cmdHelp() tea.Cmd {
   /clear                 Clear the conversation
   /exit, /quit           Exit Maestro
 
+Natural-language input runs the coding agent with ls/read/write/edit (bash is opt-in).
 Current session: %s
 
 Keyboard shortcuts:
@@ -767,7 +805,8 @@ Keyboard shortcuts:
   Ctrl+C                 Exit
   Up/Down                Scroll conversation
   i                      Enter insert mode
-  Enter                  Submit input (insert mode)`, currentSession)
+  Enter                  Submit input (insert mode)
+  Esc                    Cancel the active coding run`, currentSession)
 
 	return func() tea.Msg {
 		return ResponseMsg{Content: help}

--- a/terminal/maestro_model_test.go
+++ b/terminal/maestro_model_test.go
@@ -1,6 +1,91 @@
 package terminal
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestHandleQuestionRejectsSecondActiveCodingRun(t *testing.T) {
+	model := NewMaestroModel(&MaestroConfig{}, NewNoOpBackend("owner", "repo"))
+	first, accepted := model.handleQuestion("first task")
+	if !accepted {
+		t.Fatal("first handleQuestion() accepted = false")
+	}
+	if first == nil {
+		t.Fatal("first handleQuestion() command = nil")
+	}
+	second, accepted := model.handleQuestion("second task")
+	if accepted {
+		t.Fatal("second handleQuestion() accepted = true")
+	}
+	if second == nil {
+		t.Fatal("second handleQuestion() command = nil")
+	}
+	msg := second()
+	if _, ok := msg.(ErrorMsg); !ok {
+		t.Fatalf("second handleQuestion() message = %T, want ErrorMsg", msg)
+	}
+	if !model.codingRunActive {
+		t.Fatal("second prompt cleared active-run state")
+	}
+}
+
+func TestInputModelKeepsRejectedActiveRunPromptForEditing(t *testing.T) {
+	model := NewMaestroModel(&MaestroConfig{}, NewNoOpBackend("owner", "repo"))
+	model.codingRunActive = true
+	model.inputModel.SetValue("second task")
+
+	updated, cmd := model.inputModel.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model.inputModel = updated
+	if cmd == nil {
+		t.Fatal("Update() command = nil, want rejection message")
+	}
+	if got := model.inputModel.Value(); got != "second task" {
+		t.Fatalf("input value = %q, want rejected prompt preserved", got)
+	}
+	if history := model.inputModel.GetHistory(); len(history) != 0 {
+		t.Fatalf("history = %#v, want rejected prompt omitted", history)
+	}
+}
+
+func TestEscapeBeforeCodingCommandStartsCancelsReservedContext(t *testing.T) {
+	backend := &cancelAwareBackend{NoOpBackend: NewNoOpBackend("owner", "repo")}
+	model := NewMaestroModel(&MaestroConfig{}, backend)
+	cmd, accepted := model.handleQuestion("task")
+	if !accepted {
+		t.Fatal("handleQuestion() accepted = false")
+	}
+
+	if _, updateCmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEscape}); updateCmd != nil {
+		_ = updateCmd
+	}
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("handleQuestion() message = %T, want tea.BatchMsg", cmd())
+	}
+	for _, child := range batch {
+		if child != nil {
+			_ = child()
+		}
+	}
+	if !backend.sawCanceledContext {
+		t.Fatal("backend did not receive the pre-start canceled context")
+	}
+}
+
+type cancelAwareBackend struct {
+	*NoOpBackend
+	sawCanceledContext bool
+}
+
+func (b *cancelAwareBackend) IsReady() bool { return true }
+
+func (b *cancelAwareBackend) RunCodingTask(ctx context.Context, _ string, _ func(CodingEvent)) (string, error) {
+	b.sawCanceledContext = ctx.Err() != nil
+	return "", ctx.Err()
+}
 
 func TestPlanInputModeLayoutDropsChromeOnShortPane(t *testing.T) {
 	layout := planInputModeLayout(


### PR DESCRIPTION
## Summary

- route natural-language TUI input to a Tau/Pi-style workspace coding session while keeping `/ask` as read-only QA
- delegate execution to dspy-go v0.86 `native.Agent.ExecuteWithTrace`; no second agent loop
- register rooted `ls`, `read`, `write`, and `edit` tools, with unrestricted `bash` disabled unless `--allow-coding-bash` is explicitly set
- map typed run/turn/tool events into TUI progress and support Escape cancellation
- persist coding history under isolated internal session IDs and account from operation-scoped canonical traces
- add a `maestro-probe --strategy coding` smoke-test path and user/architecture documentation

## Safety and lifecycle

- overlapping runs are rejected and rejected input remains editable
- cancellation is reserved synchronously, including Escape before the backend command starts
- session close is terminal and replacement invalidates closed cache entries
- shutdown rejects new coding work, quiesces coding before deleting the cloned workspace or closing SQLite, and preserves independent ACE cleanup
- partial/max-turn runs remain visible stopped results instead of being reclassified as failures
- internal coding sessions are hidden from and rejected by user-facing session operations

## Battle test

A live Gemini coding probe against a temporary repository successfully created `hello.txt` with the exact requested contents. Its operation-scoped trace recorded one `coding.native` call and non-zero token usage.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run --new-from-rev=4c43e33 ./...`
- `go mod tidy -diff`
- `git diff --check`
- repeated independent Codex review; final verdict clean

## Stack

This PR is based on #107, which upgrades Maestro to dspy-go v0.86.0.
